### PR TITLE
Update systemctl-shim.sh

### DIFF
--- a/systemctl-shim.sh
+++ b/systemctl-shim.sh
@@ -1,31 +1,58 @@
+#!/bin/sh
 CMD=rc-service
 
+SERVICE=${2%".service"}
+
 case "$1" in
-	start)
-		"${CMD}" "$2" start
+        start)
+                "${CMD}" "$SERVICE" start
         ;;
 
     stop)
-		"${CMD}" "$2" stop
+                "${CMD}" "$SERVICE" stop
         ;;
 
     status)
-		"${CMD}" "$2" status
+                "${CMD}" "$SERVICE" status
         ;;
 
     restart)
-		"${CMD}" "$2" restart
+                "${CMD}" "$SERVICE" restart
         ;;
 
     enable)
-        rc-update add "$2" default
+        rc-update add "$SERVICE" default
         ;;
 
     disable)
-        rc-update del "$2" default
+        rc-update del "$SERVICE" default
         ;;
+
+    is-enabled)
+        ENABLED=`rc-update show | grep " $SERVICE " | wc -l`
+        if [ $ENABLED == "1" ]
+        then
+            echo enabled
+        else
+            echo disabled
+        fi
+        ;;
+
+    is-active)
+        ACTIVE=`rc-status | grep " $SERVICE .* started " | wc -l`
+        if [ $ACTIVE == "1" ]
+        then
+            echo active
+        else
+            echo inactive
+        fi
+        ;;
+
+    daemon-reload)
+        ;;
+
     *)
-        echo $"Usage: $0 {start|stop|status|restart}"
+        echo $"Usage: $0 {start|stop|status|restart|enable|disable|is-enabled|is-active}"
         exit 1
 
 esac


### PR DESCRIPTION
Add a shebang as kubeadm init wouldnt execute the script without it giving false positives
Added support for systemctl is-active and is-enabled as these are called by kubeadm.
OpenRC seems to keep state and if a process has crashed rc-service kubectl start doesn't seem to start the service without first using rc-service kubectl stop